### PR TITLE
Support fix widget init

### DIFF
--- a/tam-emoji/js/tam-emoji.js
+++ b/tam-emoji/js/tam-emoji.js
@@ -212,7 +212,7 @@
                     }
                 });
             };
-            
+
             context.memo('button.emoji', function () {
                 if(document.emojiButton === undefined)
                     document.emojiButton = 'fa fa-smile-o';
@@ -262,9 +262,11 @@
                     '        </div>\n' +
                     '    </div>\n' +
                     '</div>').hide();
-                this.$panel.appendTo(this.emoji.parent());
-                loadEmojis();
-                updateEmojisList(0);
+                if (typeof this,emoji !=== undefined) {
+                    this.$panel.appendTo(this.emoji.parent());
+                   loadEmojis();
+                    updateEmojisList(0);
+                }
             };
             this.destroy = function () {
                 this.$panel.remove();

--- a/tam-emoji/js/tam-emoji.js
+++ b/tam-emoji/js/tam-emoji.js
@@ -262,7 +262,7 @@
                     '        </div>\n' +
                     '    </div>\n' +
                     '</div>').hide();
-                if (typeof this,emoji !=== undefined) {
+                if (typeof this.emoji !== 'undefined') {
                     this.$panel.appendTo(this.emoji.parent());
                    loadEmojis();
                     updateEmojisList(0);


### PR DESCRIPTION
Wrike Task:[PDFs and local video no longer available in news](https://www.wrike.com/open.htm?id=405743182)

Description:
Fixed the emoji plugin's uncaught undefined variable error when the emoji is not included in every 
widget

Collect static required
This is Submodule change

Dependencies: No

Unit Tests: No

Migrations: No